### PR TITLE
Update adm-zip dependency to version 0.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "adm-zip": "0.4.7",
+        "adm-zip": "0.4.11",
         "body-parser": "1.9.0",
         "cfenv": "^1.0.4",
         "consolidate": "0.14.5",
@@ -332,9 +332,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-      "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==",
       "engines": {
         "node": ">=0.3.0"
       }
@@ -12832,9 +12832,9 @@
       "dev": true
     },
     "adm-zip": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-      "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E="
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA=="
     },
     "agent-base": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "snyk test"
   },
   "dependencies": {
-    "adm-zip": "0.4.7",
+    "adm-zip": "0.4.11",
     "body-parser": "1.9.0",
     "cfenv": "^1.0.4",
     "consolidate": "0.14.5",


### PR DESCRIPTION
This commit updates the adm-zip dependency from version 0.4.7 to version 0.4.11 in both package-lock.json and package.json files. The new version includes improved integrity checks for added security measures.
